### PR TITLE
fix not found error Apache Spark distribution

### DIFF
--- a/spark-cluster/docker/base/Dockerfile
+++ b/spark-cluster/docker/base/Dockerfile
@@ -30,7 +30,7 @@ RUN update-alternatives --install "/usr/bin/python" "python" "$(which python3)" 
 #Scala instalation
 RUN export PATH="/usr/local/sbt/bin:$PATH" &&  apt update && apt install ca-certificates wget tar && mkdir -p "/usr/local/sbt" && wget -qO - --no-check-certificate "https://github.com/sbt/sbt/releases/download/v1.2.8/sbt-1.2.8.tgz" | tar xz -C /usr/local/sbt --strip-components=1 && sbt sbtVersion
 
-RUN wget --no-verbose http://apache.mirror.iphh.net/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz && tar -xvzf spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz \
+RUN wget --no-verbose https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz && tar -xvzf spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz \
       && mv spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION} spark \
       && rm spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
 


### PR DESCRIPTION
There is an error during execution of `spark-cluster/build-images.sh`
```sh
./build-images.sh                                                                                              
[+] Building 2.0s (12/12) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                           0.0s
 => => transferring dockerfile: 37B                                                                                                                            0.0s
 => [internal] load .dockerignore                                                                                                                              0.0s
 => => transferring context: 2B                                                                                                                                0.0s
 => [internal] load metadata for docker.io/adoptopenjdk/openjdk8:latest                                                                                        1.5s
 => [auth] adoptopenjdk/openjdk8:pull token for registry-1.docker.io                                                                                           0.0s
 => [1/8] FROM docker.io/adoptopenjdk/openjdk8@sha256:594f059223cf4382bd7190960fe9fa7f91d5c3e64725111aafcb7da12a0f9f34                                         0.0s
 => CACHED [2/8] RUN apt-get update && apt-get install -y curl vim wget software-properties-common ssh net-tools ca-certificates jq dbus-x11                   0.0s
 => CACHED [3/8] RUN echo exit 0 > /usr/sbin/policy-rc.d                                                                                                       0.0s
 => CACHED [4/8] RUN cd "/tmp" &&     wget --no-verbose "https://downloads.typesafe.com/scala/2.12.10/scala-2.12.10.tgz" &&     tar xzf "scala-2.12.10.tgz" &  0.0s
 => CACHED [5/8] RUN apt-get install -y python3 python3-pip python3-numpy python3-matplotlib python3-scipy python3-pandas python3-simpy                        0.0s
 => CACHED [6/8] RUN update-alternatives --install "/usr/bin/python" "python" "$(which python3)" 1                                                             0.0s
 => CACHED [7/8] RUN export PATH="/usr/local/sbt/bin:/opt/java/openjdk/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" &&  apt update && ap  0.0s
 => ERROR [8/8] RUN wget --no-verbose http://apache.mirror.iphh.net/spark/spark-3.1.2/spark-3.1.2-bin-hadoop2.7.tgz && tar -xvzf spark-3.1.2-bin-hadoop2.7.tg  0.5s
------
 > [8/8] RUN wget --no-verbose http://apache.mirror.iphh.net/spark/spark-3.1.2/spark-3.1.2-bin-hadoop2.7.tgz && tar -xvzf spark-3.1.2-bin-hadoop2.7.tgz       && mv spark-3.1.2-bin-hadoop2.7 spark       && rm spark-3.1.2-bin-hadoop2.7.tgz:
#11 0.457 http://apache.mirror.iphh.net/spark/spark-3.1.2/spark-3.1.2-bin-hadoop2.7.tgz:
#11 0.457 2023-01-02 12:58:40 ERROR 404: Not Found.
------
executor failed running [/bin/sh -c wget --no-verbose http://apache.mirror.iphh.net/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz && tar -xvzf spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz       && mv spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION} spark       && rm spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz]: exit code: 8
```